### PR TITLE
Check the ng version properly

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -46,7 +46,10 @@ def check_exec(name: str) -> bool:
     if shut.which(name) is None:
         print('{} not found'.format(name))
         return False
-    exec('{} --version'.format(name))
+    if name is "ng":
+        exec('ng version')
+    else:
+        exec('{} --version'.format(name))
     return True
 
 


### PR DESCRIPTION
`ng` doesn't have `ng --version` argument, using the command instead. this fixes check and build scripts that failed due to `ng --version` returning an error code